### PR TITLE
#47-Correct PyYadc modules headers

### DIFF
--- a/_Global_Documentation/Typee_Software_HTML_Documentation/PyYadc/src/directory.py
+++ b/_Global_Documentation/Typee_Software_HTML_Documentation/PyYadc/src/directory.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 """
 Copyright (c) 2016-2018 Philippe Schmouker, PyYadc project, https://github.com/schmouk/PyYadc
 

--- a/_Global_Documentation/Typee_Software_HTML_Documentation/PyYadc/src/html_class.py
+++ b/_Global_Documentation/Typee_Software_HTML_Documentation/PyYadc/src/html_class.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 """
 Copyright (c) 2016-2018 Philippe Schmouker, PyYadc project, https://github.com/schmouk/PyYadc
 

--- a/_Global_Documentation/Typee_Software_HTML_Documentation/PyYadc/src/html_function.py
+++ b/_Global_Documentation/Typee_Software_HTML_Documentation/PyYadc/src/html_function.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 """
 Copyright (c) 2016-2018 Philippe Schmouker, PyYadc project, https://github.com/schmouk/PyYadc
 

--- a/_Global_Documentation/Typee_Software_HTML_Documentation/PyYadc/src/html_generator.py
+++ b/_Global_Documentation/Typee_Software_HTML_Documentation/PyYadc/src/html_generator.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 """
 Copyright (c) 2016-2018 Philippe Schmouker, PyYadc project, https://github.com/schmouk/PyYadc
 

--- a/_Global_Documentation/Typee_Software_HTML_Documentation/PyYadc/src/html_module.py
+++ b/_Global_Documentation/Typee_Software_HTML_Documentation/PyYadc/src/html_module.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 """
 Copyright (c) 2016-2018 Philippe Schmouker, PyYadc project, https://github.com/schmouk/PyYadc
 

--- a/_Global_Documentation/Typee_Software_HTML_Documentation/PyYadc/src/html_package.py
+++ b/_Global_Documentation/Typee_Software_HTML_Documentation/PyYadc/src/html_package.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 """
 Copyright (c) 2016-2018 Philippe Schmouker, PyYadc project, https://github.com/schmouk/PyYadc
 

--- a/_Global_Documentation/Typee_Software_HTML_Documentation/PyYadc/src/module_parser.py
+++ b/_Global_Documentation/Typee_Software_HTML_Documentation/PyYadc/src/module_parser.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 """
 Copyright (c) 2016-2018 Philippe Schmouker, PyYadc project, https://github.com/schmouk/PyYadc
 

--- a/_Global_Documentation/Typee_Software_HTML_Documentation/PyYadc/src/pyYadc.py
+++ b/_Global_Documentation/Typee_Software_HTML_Documentation/PyYadc/src/pyYadc.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 """
 Copyright (c) 2016-2018 Philippe Schmouker, PyYadc project, https://github.com/schmouk/PyYadc
 

--- a/_Global_Documentation/Typee_Software_HTML_Documentation/PyYadc/src/utils.py
+++ b/_Global_Documentation/Typee_Software_HTML_Documentation/PyYadc/src/utils.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 """
 Copyright (c) 2016-2018 Philippe Schmouker, PyYadc project, https://github.com/schmouk/PyYadc
 


### PR DESCRIPTION
The control line for the python interpreter and the other control line for the coding of modules have been added