### PR TITLE
#42-Front-End-Elaborator-Preparation

### DIFF
--- a/src/FrontEnd/Elaborator/fe_elaborator.py
+++ b/src/FrontEnd/Elaborator/fe_elaborator.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Copyright (c) 2018 Philippe Schmouker, Typee project, http://www.typee.ovh
+
+Permission is hereby granted,  free of charge,  to any person obtaining a copy
+of this software and associated documentation files (the "Software"),  to deal
+in the Software without restriction, including  without  limitation the rights
+to use,  copy,  modify,  merge,  publish,  distribute, sublicense, and/or sell
+copies of the Software,  and  to  permit  persons  to  whom  the  Software  is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS",  WITHOUT WARRANTY OF ANY  KIND,  EXPRESS  OR
+IMPLIED,  INCLUDING  BUT  NOT  LIMITED  TO  THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT  SHALL  THE
+AUTHORS  OR  COPYRIGHT  HOLDERS  BE  LIABLE  FOR  ANY CLAIM,  DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  TORT OR OTHERWISE, ARISING FROM,
+OUT  OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+#=============================================================================
+# no import.
+
+
+#=============================================================================
+class FEElaborator:
+    """
+    Bse class for the Elabioration step of Typee front-End.
+    """    
+    #-------------------------------------------------------------------------
+    def __init__(self, params):
+        '''
+        Constructor.
+        
+        description
+        
+        Args:
+            ...
+        
+        Returns:
+            ...
+        
+        Raises:
+            ...
+        '''
+        pass
+   
+    #-------------------------------------------------------------------------
+
+#=====   end of   FrontEnd.Elaborator.fe_elaborator   =====#

--- a/src/FrontEnd/Elaborator/fe_symbols_elaborator.py
+++ b/src/FrontEnd/Elaborator/fe_symbols_elaborator.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Copyright (c) 2018 Philippe Schmouker, Typee project, http://www.typee.ovh
+
+Permission is hereby granted,  free of charge,  to any person obtaining a copy
+of this software and associated documentation files (the "Software"),  to deal
+in the Software without restriction, including  without  limitation the rights
+to use,  copy,  modify,  merge,  publish,  distribute, sublicense, and/or sell
+copies of the Software,  and  to  permit  persons  to  whom  the  Software  is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS",  WITHOUT WARRANTY OF ANY  KIND,  EXPRESS  OR
+IMPLIED,  INCLUDING  BUT  NOT  LIMITED  TO  THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT  SHALL  THE
+AUTHORS  OR  COPYRIGHT  HOLDERS  BE  LIABLE  FOR  ANY CLAIM,  DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  TORT OR OTHERWISE, ARISING FROM,
+OUT  OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+#=============================================================================
+from FrontEnd.Elaborator.fe_elaborator import FEElaborator
+
+
+#=============================================================================
+class FESymbolsElaborator( FEElaborator ):
+    """
+    Class description.
+    """    
+    #-------------------------------------------------------------------------
+    def __init__(self, params):
+        '''
+        Constructor.
+        
+        description
+        
+        Args:
+            ...
+        
+        Returns:
+            ...
+        
+        Raises:
+            ...
+        '''
+        super().__init__()
+   
+    #-------------------------------------------------------------------------
+
+#=====   end of   FrontEnd.Elaborator.fe_symbols_elaborator   =====#

--- a/src/FrontEnd/Elaborator/fe_types_elaborator.py
+++ b/src/FrontEnd/Elaborator/fe_types_elaborator.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Copyright (c) 2018 Philippe Schmouker, Typee project, http://www.typee.ovh
+
+Permission is hereby granted,  free of charge,  to any person obtaining a copy
+of this software and associated documentation files (the "Software"),  to deal
+in the Software without restriction, including  without  limitation the rights
+to use,  copy,  modify,  merge,  publish,  distribute, sublicense, and/or sell
+copies of the Software,  and  to  permit  persons  to  whom  the  Software  is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS",  WITHOUT WARRANTY OF ANY  KIND,  EXPRESS  OR
+IMPLIED,  INCLUDING  BUT  NOT  LIMITED  TO  THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT  SHALL  THE
+AUTHORS  OR  COPYRIGHT  HOLDERS  BE  LIABLE  FOR  ANY CLAIM,  DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  TORT OR OTHERWISE, ARISING FROM,
+OUT  OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+#=============================================================================
+from FrontEnd.Elaborator.fe_elaborator import FEElaborator
+
+
+#=============================================================================
+class FETypesElaborator( FEElaborator ):
+    """
+    Class description.
+    """    
+    #-------------------------------------------------------------------------
+    def __init__(self, params):
+        '''
+        Constructor.
+        
+        description
+        
+        Args:
+            ...
+        
+        Returns:
+            ...
+        
+        Raises:
+            ...
+        '''
+        pass
+   
+    #-------------------------------------------------------------------------
+
+#=====   end of   FrontEnd.Elaborator.fe_types_elaborator   =====#


### PR DESCRIPTION
Added three modules for the Elaboration step of __Typee__ Front-End.
These modules are currently nearly "empty". They only contain each the definition of a related class definition and the associated inheritances.
This is just preparation for further work. It has been done now, while S/W design documentation is being written.