### PR TITLE
#104-Correct-Modify built-in Libraries

### DIFF
--- a/src/Libs/SysTime/perfmeter.ty
+++ b/src/Libs/SysTime/perfmeter.ty
@@ -1,0 +1,187 @@
+/***
+Copyright (c) 2018-2019 Philippe Schmouker, schmouk (at) typee.ovh
+
+Permission is hereby granted,  free of charge,  to any person obtaining a copy
+of this software and associated documentation files (the "Software"),  to deal
+in the Software without restriction, including  without  limitation the rights
+to use,  copy,  modify,  merge,  publish,  distribute, sublicense, and/or sell
+copies of the Software,  and  to  permit  persons  to  whom  the  Software  is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS",  WITHOUT WARRANTY OF ANY  KIND,  EXPRESS  OR
+IMPLIED,  INCLUDING  BUT  NOT  LIMITED  TO  THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT  SHALL  THE
+AUTHORS  OR  COPYRIGHT  HOLDERS  BE  LIABLE  FOR  ANY CLAIM,  DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  TORT OR OTHERWISE, ARISING FROM,
+OUT  OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+***/
+
+//=============================================================================
+// Built-in Library SysTime
+// Module perfmeter.py
+// See online documentation at https://www.typee.ovh,
+// section "5.SysTime Library" of tab "Documentation"
+
+//=============================================================================
+from SysTime.systime import proctime_ns;
+
+//=============================================================================
+class PerfMeter
+/** 
+Class of performance meters.  Provides times with nanoseconds  precision  when 
+possible and with milliseconds precision otherwise.
+Notice: actual C# implementation of systime allows only milliseconds precision.
+*/
+{
+  :public:
+    //---------------------------------------------------------------------
+    PerfMeter(){
+        me._frmt, me._frmt16 = none, none;
+        me._mark  = none;
+        me._start = proctime_ns();
+    }
+    //---------------------------------------------------------------------
+    PerfMeter( const str format ){
+        me._frmt, me._frmt16 = format, none;
+        me._mark  = none;
+        me._start = proctime_ns();
+    }
+    //---------------------------------------------------------------------
+    PerfMeter( const str16 format ){
+        me._frmt, me._frmt16 = none, format;
+        me._mark  = none;
+        me._start = proctime_ns();
+    }
+
+    //---------------------------------------------------------------------
+    none destroy (){
+        me._mark = proctime_ns();
+        print( str16(me) if me._frmt16 is not none else str(me) );
+    }
+
+    //---------------------------------------------------------------------
+    none mark(){
+        me._mark = proctime_ns();
+    }
+
+    //---------------------------------------------------------------------
+    none restart(){
+        me._mark  = none;
+        me._start = proctime_ns();
+    }
+
+    //---------------------------------------------------------------------
+    str operator str () {
+        if ( me._mark is none )
+            me._mark = proctime_ns();
+        if ( me._frmt is none )
+            return me._default_format.format( me._mark - me._start );
+        else
+            return me.frmt.format( me._mark - me._start );
+    }
+    //---------------------------------------------------------------------
+    str16 operator str16 () {
+        if ( me._mark is none )
+            me._mark = proctime_ns();
+        if ( me._frmt16 is none )
+            return me._default_format16.format( me._mark - me._start );
+        else
+            return me.frmt16.format( me._mark - me._start );
+    }
+
+  :protected:
+    //---------------------------------------------------------------------  
+    float64  _start, _mark;
+    str      _frmt;
+    str16    _frmt16;
+    
+    static str   _default_format   = "\n-- done in {:.6f} s";
+    static str16 _default_format16 = str16( "\n-- done in {:.6f} s" );
+}
+
+//=============================================================================
+class PerfMeterHms : PerfMeter
+/** 
+Class of performance meters.  Provides times with nanoseconds  precision  when 
+possible and with milliseconds precision otherwise.
+Notice: actual C# implementation of systime allows only milliseconds precision.
+Elapsed times are displayed with format 'HH:MM:SS.frac'.
+*/
+{
+  :public:
+    //---------------------------------------------------------------------
+    PerfMeterHms(){
+        me._decimals = me._K_DEFAULT_DECIMALS;
+        PerfMeter();
+    }
+    //---------------------------------------------------------------------
+    PerfMeterHms( const uint8 decimals){
+        me._decimals = decimals;
+        PerfMeter();
+    }
+    //---------------------------------------------------------------------
+    PerfMeterHms( const ? in (str,str16) format ){
+        me._decimals = me._K_DEFAULT_DECIMALS;
+        PerfMeter( format );
+    }
+    //---------------------------------------------------------------------
+    PerfMeterHms( const ? in (str,str16) format, const uint8 decimals ){
+        me._decimals = decimals;
+        PerfMeter( format );
+    }
+
+    //---------------------------------------------------------------------
+    str operator str () {
+        str time_text;
+        if ( me._mark is none )
+            me._mark = proctime_ns();
+        const float64 elapsed = me._mark - me._start;
+        const uint64  intElapsed = uint64( elapsed );
+        const uint8   s = intElapsed % 60;
+        if ( intElapsed >= 3600 ){
+            const uint64 h = intElapsed / 3600;
+            const uint8  m = (intElapsed / 60) % 60;
+            time_text = "{:d}:{:=2d}:{:=2d}".format( h, m, s )
+                                + me._frmt_decs(decimals, elapsed-intElapsed);
+        }
+        else{
+            const uint8 m = intElapsed / 60;
+            time_text =  "{:d}:{:=2d}".format( m, s )
+                                + me._frmt_decs(decimals, elapsed-intElapsed);
+        }
+        if ( me._frmt is none )
+            return me._default_format.format( time_text );
+        else
+            return me._frmt.format( time_text );
+    }
+    //---------------------------------------------------------------------
+    str16 operator str16 () {
+        return str16( str(me) );
+    }
+
+  :hidden:
+    //---------------------------------------------------------------------
+    const str _frmt_decs( const float64 val ){
+        if ( me._decimals == 0 )
+            return '';
+        elif ( me._decimals == 1 )
+            return ".{:1d}".format( uint64(val*10 + 0.5) );
+        else{
+            me._decimals = min( me._K_MAX_DECIMALS, me._decimals );
+            str frmt = ".\{:={:d}d\}".format( me._decimals );
+            return frmt.format( uint64(val * (10^^me._decimals) + 0.5) );
+        }
+    }
+
+    //---------------------------------------------------------------------
+    uint8         _decimals;
+    static uint8  _K_DEFAULT_DECIMALS = 3;
+    static uint8  _K_MAX_DECIMALS     = 6;
+    static str    _default_format     = "\n-- done in {:s}";
+}
+
+//=====   end of module Libs.SysTime.perfmeter.ty   =====//


### PR DESCRIPTION
Fixed comment about online documentation in module `SysTime/perfmeter.ty`.