### PR TITLE
#85-Modify-Correct Typee Syntax

### DIFF
--- a/Language-specifications/typee_specs_LL1-v9-EBNF.grm
+++ b/Language-specifications/typee_specs_LL1-v9-EBNF.grm
@@ -408,9 +408,10 @@ SOFTWARE.
 <embed statement>           ::= 'embed' <language>
                                     (<dotted name> <simple statement end>  |
                                      <embedded language code>)
+                                    [ 'exit' ]
 
 <embedded language code>    ::= '{{' <embedded language code'>
-<embeded language code'>    ::= <any embedded code char> <embeded language code'>  |
+<embedded language code'>   ::= <any embedded code char> <embeded language code'>  |
                                 '}' <embedded language code">
 <embedded language code">   ::= <any embedded code char> <embeded language code'>  |
                                 '}' 

--- a/Language-specifications/typee_specs_LL1-v9.grm
+++ b/Language-specifications/typee_specs_LL1-v9.grm
@@ -577,8 +577,10 @@ SOFTWARE.
                              | EPS
 
 <embed statement>           ::= 'embed' <language> <embed statement'>
-<embed statement'>          ::= <dotted name> <simple statement end>
-                             |  <embedded language code>
+<embed statement'>          ::= <dotted name> <simple statement end> <embed statement''>    ###
+                             |  <embedded language code> <embed statement''>                ###
+<embed statement''>         ::= 'exit'                                                      ###
+                             |  EPS                                                         ###
 
 <embedded language code>    ::= '{{' <embedded language code'>
 <embeded language code'>    ::= <any embedded code char> <embeded language code'>


### PR DESCRIPTION
Added keyword `exit` in both versions v9 and v9-EBNF of typee grammar specs document.