### PR TITLE
#85-Modify-Correct Typee syntax

### DIFF
--- a/Language-specifications/typee_specs_LL1-v9-1-EBNF.grm
+++ b/Language-specifications/typee_specs_LL1-v9-1-EBNF.grm
@@ -40,7 +40,8 @@ SOFTWARE.
                             ( <dotted name'> | <function call> |
                             <subscription or slicing> )*
 
-<atom>                  ::= [<decr>|<incr>] <dotted name> [<decr>|<incr>]  |
+<atom>                  ::= [<decr>|<incr>] <dotted name>                           ###
+                                [<decr>|<incr> | <for comprehension>] |             ###
                             <enclosure>  |  <reference>  |  <scalar>  |
                             <string>  |  <boolean>
 

--- a/Language-specifications/typee_specs_LL1-v9-1.grm
+++ b/Language-specifications/typee_specs_LL1-v9-1.grm
@@ -45,12 +45,14 @@ SOFTWARE.
 
 <atom>          ::= <decr> <dotted name> <incr or decr>
                  |  <incr> <dotted name> <incr or decr>
-                 |  <dotted name> <incr or decr>
+                 |  <dotted name> <atom'>                               ###
                  |  <enclosure>
                  |  <reference>
                  |  <scalar>
                  |  <string>
                  |  <boolean>
+<atom'>         ::= <incr or decr>                                      ###
+                 |  <for comprehension>                                 ###
 
 <boolean>       ::= <TRUE>
                  |  <FALSE>
@@ -64,7 +66,9 @@ SOFTWARE.
 
 <incr>          ::= '++'
 
-<incr or decr>  ::= <decr>  |  <incr>  |  EPS
+<incr or decr>  ::= <decr>
+                 |  <incr>
+                 |  EPS
 
 <is instance of>    ::= '->' <dotted name>
 


### PR DESCRIPTION
Added `for comprehension` rule as legal in assignment statement with a list of assigned objects on the left side of operator `=`.