### PR TITLE
#85-Modify-Correct Typee syntax

### DIFF
--- a/Language-specifications/typee_specs_LL1-v9-1-EBNF.grm
+++ b/Language-specifications/typee_specs_LL1-v9-1-EBNF.grm
@@ -40,10 +40,11 @@ SOFTWARE.
                             ( <dotted name'> | <function call> |
                             <subscription or slicing> )*
 
-<atom>                  ::= [<decr>|<incr>] <dotted name>                           ###
-                                [<decr>|<incr> | <for comprehension>] |             ###
-                            <enclosure>  |  <reference>  |  <scalar>  |
-                            <string>  |  <boolean>
+<atom>                  ::= (<decr>|<incr>) <dotted name> [<decr>|<incr>] |
+                            <dotted name>
+                                [<decr> | <incr> | <for comprehension> ]  |
+                            <enclosure>  |  <reference>  |  <scalar>      |
+                            <string>     |  <boolean>
 
 <boolean>               ::= <TRUE>  |  <FALSE>
 


### PR DESCRIPTION
Corrected new grammar rule `<atom>`.