### PR TITLE
#85-Modify-Correct Typee syntax

### DIFF
--- a/Language-specifications/typee_specs_LL1-v9-1.grm
+++ b/Language-specifications/typee_specs_LL1-v9-1.grm
@@ -45,14 +45,14 @@ SOFTWARE.
 
 <atom>          ::= <decr> <dotted name> <incr or decr>
                  |  <incr> <dotted name> <incr or decr>
-                 |  <dotted name> <atom'>                               ###
+                 |  <dotted name> <atom'>
                  |  <enclosure>
                  |  <reference>
                  |  <scalar>
                  |  <string>
                  |  <boolean>
-<atom'>         ::= <incr or decr>                                      ###
-                 |  <for comprehension>                                 ###
+<atom'>         ::= <incr or decr>
+                 |  <for comprehension>
 
 <boolean>       ::= <TRUE>
                  |  <FALSE>


### PR DESCRIPTION
removed temporary comments in version v9-1 of Typee syntax specifications document.